### PR TITLE
Updating doctoc to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,27 +25,20 @@
   "scripts": {
     "init": "rimraf .validate.json && rimraf .jshintrc",
     "clean": "rimraf dist",
-
     "start": "tsc -w",
-
     "prebuild": "npm run clean",
     "build": "tsc",
     "build:doc": "doctoc --github --title \"## Contents\" ./",
-
     "lint": "eslint source test",
     "validate": "npm run lint && npm run build && npm test",
     "validate-dev": "npm run lint && npm run build && npm test | faucet",
-
     "pretest": "tsc test/*.ts --module commonjs",
     "test": "mocha dist/test/",
     "test:w": "mocha dist/test/ -w",
-
     "audit": "nsp package",
-
     "deps": "npm run deps:missing && npm run deps:extra",
     "deps:missing": "dependency-check package.json",
     "deps:extra": "dependency-check package.json --extra --no-dev --ignore",
-
     "precheck": "npm run validate",
     "check": "npm run audit && npm run deps && npm outdated --depth 0"
   },
@@ -55,7 +48,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "dependency-check": "^2.5.0",
-    "doctoc": "^0.14.2",
+    "doctoc": "^1.0.0",
     "eslint": "^1.1.0",
     "eslint-loader": "^1.0.0",
     "faucet": "0.0.1",


### PR DESCRIPTION
Please update [doctoc](https://npmjs.org/package/doctoc) to version 1.0.0.

If this passes your tests you can merge it in.  If not please use this branch for changes.
- [`9be6426`](https://github.com/thlorenz/doctoc/commit/9be642613e4dbf328cfd42f25b714edea0de8875) `1.0.0`
- [`4000d12`](https://github.com/thlorenz/doctoc/commit/4000d121ccb2fddb82d1c3f3c26dbf1a239f12e5) `Parse headers as Markdown`
- [`963b4da`](https://github.com/thlorenz/doctoc/commit/963b4da8e703a7160fdacef1c7ed655fb3d3500f) `Correct README`
- [`bb4968b`](https://github.com/thlorenz/doctoc/commit/bb4968bc6795358d5f35f313393858dcc8b5c61f) `0.15.0`
- [`27a1c1b`](https://github.com/thlorenz/doctoc/commit/27a1c1b10b209a942cbc12fa79c91e5882efb23c) `Process all args in a loop`

View the [change log](https://github.com/thlorenz/doctoc/compare/ea0d19faaebb90f29fde3cc278c58a4d85f3d424...9be642613e4dbf328cfd42f25b714edea0de8875).
